### PR TITLE
Improve the demo quality

### DIFF
--- a/Project/Gem/Source/VehicleController/VehicleController.cpp
+++ b/Project/Gem/Source/VehicleController/VehicleController.cpp
@@ -75,7 +75,8 @@ namespace RAIControl
                 ->Field("predefinedPaths", &VehicleControllerConfig::m_predefinedPaths)
                 ->Field("predefinedObstacles", &VehicleControllerConfig::m_predefinedObstacles)
                 ->Field("vehicleLights", &VehicleControllerConfig::m_vehicleLights)
-                ->Field("vehicleLightsIntensities", &VehicleControllerConfig::m_vehicleLightsIntensities);
+                ->Field("vehicleLightsIntensities", &VehicleControllerConfig::m_vehicleLightsIntensities)
+                ->Field("obstacleDistanceThreshold", &VehicleControllerConfig::m_obstacleDistanceThreshold);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
@@ -112,7 +113,12 @@ namespace RAIControl
                         AZ::Edit::UIHandlers::Default,
                         &VehicleControllerConfig::m_vehicleLightsIntensities,
                         "Vehicle lights' intensities",
-                        "List of the max. intensities for vehicle lights");
+                        "List of the max. intensities for vehicle lights")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &VehicleControllerConfig::m_obstacleDistanceThreshold,
+                        "Obstacle distance threshold",
+                        "Distance threshold for the vehicle to stop when an obstacle is detected");
             }
         }
     }

--- a/Project/Gem/Source/VehicleController/VehicleController.h
+++ b/Project/Gem/Source/VehicleController/VehicleController.h
@@ -50,6 +50,7 @@ namespace RAIControl
         AZStd::vector<AZ::EntityId> m_predefinedObstacles;
         AZStd::vector<AZ::EntityId> m_vehicleLights;
         AZStd::vector<float> m_vehicleLightsIntensities;
+        float m_obstacleDistanceThreshold{ 7.0f };
     };
 
 } // namespace RAIControl

--- a/Project/Gem/Source/VehicleController/VehicleController.h
+++ b/Project/Gem/Source/VehicleController/VehicleController.h
@@ -50,6 +50,8 @@ namespace RAIControl
         AZStd::vector<AZ::EntityId> m_predefinedObstacles;
         AZStd::vector<AZ::EntityId> m_vehicleLights;
         AZStd::vector<float> m_vehicleLightsIntensities;
+
+        // Distance from the obstacle at which the tractor will stop
         float m_obstacleDistanceThreshold{ 7.0f };
     };
 

--- a/Project/Gem/Source/VehicleController/VehicleControllerComponent.cpp
+++ b/Project/Gem/Source/VehicleController/VehicleControllerComponent.cpp
@@ -244,7 +244,7 @@ namespace RAIControl
             AZ::Vector3 obstacleTranslation = AZ::Vector3::CreateZero();
             AZ::TransformBus::EventResult(obstacleTranslation, obstacleId, &AZ::TransformBus::Events::GetWorldTranslation);
 
-            if ((obstacleTranslation - vehiclePosition).GetLength() < 5.0)
+            if ((obstacleTranslation - vehiclePosition).GetLength() < m_configuration.m_obstacleDistanceThreshold)
             {
                 // Set the flag and stop the vehicle
                 if (!m_obstacleDetected)

--- a/Project/Levels/AlmondOrchard/AlmondOrchard.prefab
+++ b/Project/Levels/AlmondOrchard/AlmondOrchard.prefab
@@ -1505,6 +1505,141 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Instances/Instance_[73412310835229]/Entities/Entity_[122431352745838]/Components/EditorRigidBodyComponent/Configuration/Initial angular velocity/2",
+                    "value": 5.099999904632568
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[73412310835229]/Entities/Entity_[122431352745838]/Components/TransformComponent/Transform Data/Rotate/2",
+                    "value": 35.0
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/22"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/21"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/20"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/19"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/18"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/17"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/16"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/15"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/14"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/13"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/12"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/11"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/10"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/9"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/8"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/7/Forward/0",
+                    "value": 79.0
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/22"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/21"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/20"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/19"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/18"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/17"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/16"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/15"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/14"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/13"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/12"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/11"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/10"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/9"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/8"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/ShapeColor/0",
                     "value": 1.0
                 },
@@ -1512,6 +1647,66 @@
                     "op": "replace",
                     "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/ShapeColor/2",
                     "value": 0.0
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/22"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/21"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/20"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/19"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/18"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/17"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/16"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/15"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/14"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/13"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/12"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/11"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/10"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/9"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/8"
                 },
                 {
                     "op": "replace",
@@ -1522,16 +1717,6 @@
                     "op": "replace",
                     "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShapeMeshConfig/ShapeConfig/DrawColor/2",
                     "value": 0.0
-                },
-                {
-                    "op": "replace",
-                    "path": "/Instances/Instance_[73412310835229]/Entities/Entity_[122431352745838]/Components/EditorRigidBodyComponent/Configuration/Initial angular velocity/2",
-                    "value": 5.099999904632568
-                },
-                {
-                    "op": "replace",
-                    "path": "/Instances/Instance_[73412310835229]/Entities/Entity_[122431352745838]/Components/TransformComponent/Transform Data/Rotate/2",
-                    "value": 35.0
                 }
             ]
         },
@@ -5251,6 +5436,191 @@
                     "op": "replace",
                     "path": "/Instances/Instance_[51405573643237]/Entities/Entity_[2144213563765]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "tractor1"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/22"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/21"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/20"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/19"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/18"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/17"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/16"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/15"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/14"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/13"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/12"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/11"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/10"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/9"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Vertices/Vertices/8"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/7/Forward/0",
+                    "value": 79.0
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/22"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/21"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/20"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/19"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/18"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/17"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/16"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/15"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/14"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/13"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/12"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/11"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/10"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/9"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorSplineComponent/Configuration/Spline/Bezier Data/8"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/22"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/21"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/20"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/19"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/18"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/17"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/16"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/15"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/14"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/13"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/12"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/11"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/10"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/9"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[253776731796994]/Components/EditorTubeShapeComponent/TubeShape/VariableRadius/Elements/8"
                 }
             ]
         },


### PR DESCRIPTION
This PR adds two small changes to the project to improve its quality:
- Added a variable for controlling the threshold of distance from an obstacle at which the tractor will stop: previously it was hardcoded to 5.0 meters which was so small that the object did not fully fit inside the tractors camera view, increased it to 7.0 meters.
![image](https://github.com/user-attachments/assets/f9d56015-9c8c-4fe1-827d-e67309596350)
![image](https://github.com/user-attachments/assets/936dcb74-082c-4ece-b5ef-874437e2d77a)
- Adjusted tractors' paths to end in the last two rows of the field, instead of outside of the screen.
![image](https://github.com/user-attachments/assets/409ab612-913b-4061-835f-9970c6020269)
